### PR TITLE
chatbot API v1

### DIFF
--- a/src/main/java/com/lealtixservice/controller/OrderSseController.java
+++ b/src/main/java/com/lealtixservice/controller/OrderSseController.java
@@ -1,0 +1,28 @@
+package com.lealtixservice.controller;
+
+import com.lealtixservice.service.OrderSseService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Tag(name = "SSE Orders", description = "Server-Sent Events para notificaciones de órdenes en tiempo real")
+@RestController
+@RequestMapping("/api/sse")
+@RequiredArgsConstructor
+public class OrderSseController {
+
+    private final OrderSseService orderSseService;
+
+    @GetMapping(value = "/orders", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamOrders(@RequestParam Long tenantId) {
+        log.info("[SSE] Nueva suscripción SSE para tenant {}", tenantId);
+        return orderSseService.subscribe(tenantId);
+    }
+}

--- a/src/main/java/com/lealtixservice/dto/OrderSseEventDTO.java
+++ b/src/main/java/com/lealtixservice/dto/OrderSseEventDTO.java
@@ -1,0 +1,127 @@
+package com.lealtixservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * DTO específico para eventos SSE de nuevas órdenes.
+ * Estructura optimizada para el frontend con todos los campos requeridos.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderSseEventDTO {
+
+    @JsonProperty("type")
+    private String type; // Siempre "new-order"
+
+    @JsonProperty("tenantId")
+    private Long tenantId;
+
+    @JsonProperty("timestamp")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+    private Instant timestamp;
+
+    @JsonProperty("meta")
+    private MetaDTO meta;
+
+    @JsonProperty("order")
+    private OrderDataDTO order;
+
+    /**
+     * Metadata del evento
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MetaDTO {
+        @JsonProperty("origin")
+        private String origin; // "CHATBOT"
+    }
+
+    /**
+     * Datos completos de la orden
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderDataDTO {
+        @JsonProperty("id")
+        private String id; // UUID como string
+
+        @JsonProperty("tenantId")
+        private Long tenantId;
+
+        @JsonProperty("customerId")
+        private Long customerId; // null si es venta general
+
+        @JsonProperty("customerName")
+        private String customerName; // null si es venta general
+
+        @JsonProperty("estado")
+        private String estado; // "PENDING", "PAID", "CANCELLED" (inglés para FE)
+
+        @JsonProperty("source")
+        private String source; // "CHATBOT"
+
+        @JsonProperty("subtotal")
+        private BigDecimal subtotal;
+
+        @JsonProperty("descuento")
+        private BigDecimal descuento;
+
+        @JsonProperty("total")
+        private BigDecimal total;
+
+        @JsonProperty("items")
+        private List<OrderItemDataDTO> items;
+
+        @JsonProperty("couponCode")
+        private String couponCode; // null si no hay cupón
+
+        @JsonProperty("couponId")
+        private String couponId; // null si no hay cupón (Long como string para consistencia)
+
+        @JsonProperty("couponDiscount")
+        private BigDecimal couponDiscount; // 0 si no hay cupón
+
+        @JsonProperty("fecha")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+        private Instant fecha;
+    }
+
+    /**
+     * Datos de item de la orden
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItemDataDTO {
+        @JsonProperty("productId")
+        private Long productId;
+
+        @JsonProperty("productName")
+        private String productName;
+
+        @JsonProperty("cantidad")
+        private Integer cantidad;
+
+        @JsonProperty("precioUnitario")
+        private BigDecimal precioUnitario;
+
+        @JsonProperty("comentarios")
+        private String comentarios; // null si no hay comentarios
+    }
+}

--- a/src/main/java/com/lealtixservice/service/OrderSseService.java
+++ b/src/main/java/com/lealtixservice/service/OrderSseService.java
@@ -1,0 +1,229 @@
+package com.lealtixservice.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lealtixservice.dto.ClientOrderDTO;
+import com.lealtixservice.dto.ClientOrderItemDTO;
+import com.lealtixservice.dto.OrderSseEventDTO;
+import com.lealtixservice.enums.OrderStatus;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderSseService {
+
+    private static final long SSE_TIMEOUT = 30L * 60L * 1000L; // 30 minutos
+    private static final String PING_EVENT = "ping";
+    private static final String NEW_ORDER_EVENT = "new-order";
+
+    private final ObjectMapper objectMapper;
+
+    // Map tenantId -> lista de emitters activos
+    private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emittersByTenant = new ConcurrentHashMap<>();
+
+    /**
+     * Registra un nuevo SseEmitter para el tenant dado.
+     * Configura callbacks de limpieza en complete/timeout/error.
+     */
+    public SseEmitter subscribe(Long tenantId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+
+        emittersByTenant.computeIfAbsent(tenantId, id -> new CopyOnWriteArrayList<>()).add(emitter);
+        log.info("[SSE] Cliente suscrito al tenant {}. Total emitters activos: {}", tenantId,
+                emittersByTenant.get(tenantId).size());
+
+        Runnable cleanup = () -> {
+            removeEmitter(tenantId, emitter);
+            log.info("[SSE] Emitter removido para tenant {}. Restantes: {}",
+                    tenantId, emittersByTenant.getOrDefault(tenantId, new CopyOnWriteArrayList<>()).size());
+        };
+
+        emitter.onCompletion(cleanup);
+        emitter.onTimeout(cleanup);
+        emitter.onError(e -> {
+            log.warn("[SSE] Error en emitter del tenant {}: {}", tenantId, e.getMessage());
+            cleanup.run();
+        });
+
+        // Enviar evento inicial de conexión establecida
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data(Map.of("status", "connected", "tenantId", tenantId, "timestamp", Instant.now().toString())));
+        } catch (IOException e) {
+            log.warn("[SSE] No se pudo enviar evento 'connected' al tenant {}: {}", tenantId, e.getMessage());
+            emitter.complete();
+        }
+
+        return emitter;
+    }
+
+    /**
+     * Envía evento 'new-order' solo cuando la orden viene de CHATBOT y está en PENDIENTE.
+     * Construye el payload completo con toda la información requerida por el frontend.
+     */
+    public void publishNewChatbotOrder(ClientOrderDTO order) {
+        Long tenantId = order.getTenantId();
+        List<SseEmitter> emitters = emittersByTenant.getOrDefault(tenantId, new CopyOnWriteArrayList<>());
+
+        if (emitters.isEmpty()) {
+            log.debug("[SSE] No hay suscriptores activos para tenant {}. Evento descartado.", tenantId);
+            return;
+        }
+
+        try {
+            // Construir el evento SSE completo con toda la información
+            OrderSseEventDTO event = buildOrderSseEvent(order);
+            String payload = objectMapper.writeValueAsString(event);
+            
+            log.info("[SSE] Enviando evento new-order para tenant {}, orden {}", tenantId, order.getId());
+            sendToTenant(tenantId, NEW_ORDER_EVENT, payload);
+        } catch (Exception e) {
+            log.error("[SSE] Error serializando orden para SSE, tenant {}: {}", tenantId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Construye el DTO del evento SSE con toda la información completa de la orden
+     */
+    private OrderSseEventDTO buildOrderSseEvent(ClientOrderDTO order) {
+        Instant timestamp = Instant.now();
+        
+        // Mapear items
+        List<OrderSseEventDTO.OrderItemDataDTO> items = new ArrayList<>();
+        if (order.getItems() != null) {
+            items = order.getItems().stream()
+                    .map(this::mapOrderItem)
+                    .collect(Collectors.toList());
+        }
+
+        // Mapear estado de español a inglés para el frontend
+        String estadoEn = mapEstadoToEnglish(order.getEstado());
+
+        // Construir datos de la orden
+        OrderSseEventDTO.OrderDataDTO orderData = OrderSseEventDTO.OrderDataDTO.builder()
+                .id(order.getId().toString())
+                .tenantId(order.getTenantId())
+                .customerId(order.getCustomerId())
+                .customerName(order.getCustomerName())
+                .estado(estadoEn)
+                .source(order.getSource() != null ? order.getSource() : "CHATBOT")
+                .subtotal(order.getSubtotal() != null ? order.getSubtotal() : BigDecimal.ZERO)
+                .descuento(order.getDescuento() != null ? order.getDescuento() : BigDecimal.ZERO)
+                .total(order.getTotal() != null ? order.getTotal() : BigDecimal.ZERO)
+                .items(items)
+                .couponCode(order.getCouponCode())
+                .couponId(order.getCouponId() != null ? order.getCouponId().toString() : null)
+                .couponDiscount(order.getCouponDiscount() != null ? order.getCouponDiscount() : BigDecimal.ZERO)
+                .fecha(order.getFecha() != null ? order.getFecha().toInstant(ZoneOffset.UTC) : timestamp)
+                .build();
+
+        // Construir metadata
+        OrderSseEventDTO.MetaDTO meta = OrderSseEventDTO.MetaDTO.builder()
+                .origin("CHATBOT")
+                .build();
+
+        // Construir evento completo
+        return OrderSseEventDTO.builder()
+                .type(NEW_ORDER_EVENT)
+                .tenantId(order.getTenantId())
+                .timestamp(timestamp)
+                .meta(meta)
+                .order(orderData)
+                .build();
+    }
+
+    /**
+     * Mapea un item de orden al DTO del evento SSE
+     */
+    private OrderSseEventDTO.OrderItemDataDTO mapOrderItem(ClientOrderItemDTO item) {
+        return OrderSseEventDTO.OrderItemDataDTO.builder()
+                .productId(item.getProductId())
+                .productName(item.getProductName())
+                .cantidad(item.getCantidad())
+                .precioUnitario(item.getPrecioUnitario() != null ? item.getPrecioUnitario() : BigDecimal.ZERO)
+                .comentarios(item.getComentarios())
+                .build();
+    }
+
+    /**
+     * Mapea el estado de la orden de español (BD) a inglés (frontend)
+     */
+    private String mapEstadoToEnglish(OrderStatus estado) {
+        if (estado == null) return "PENDING";
+        
+        return switch (estado) {
+            case PENDIENTE -> "PENDING";
+            case PAGADA -> "PAID";
+            case CANCELADA -> "CANCELLED";
+        };
+    }
+
+    /**
+     * Ping cada 30 segundos a todos los tenants con suscriptores activos.
+     * Evita que proxies/load balancers cierren la conexión por inactividad.
+     */
+    @Scheduled(fixedDelay = 30_000)
+    public void sendHeartbeat() {
+        emittersByTenant.forEach((tenantId, emitters) -> {
+            if (!emitters.isEmpty()) {
+                String pingData = "{\"timestamp\":\"" + Instant.now().toString() + "\"}";
+                sendToTenant(tenantId, PING_EVENT, pingData);
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers privados
+    // -------------------------------------------------------------------------
+
+    private void sendToTenant(Long tenantId, String eventName, String data) {
+        List<SseEmitter> emitters = emittersByTenant.getOrDefault(tenantId, new CopyOnWriteArrayList<>());
+        List<SseEmitter> dead = new ArrayList<>();
+
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event().name(eventName).data(data));
+            } catch (Exception e) {
+                log.warn("[SSE] Emitter muerto en tenant {}, removiendo. Causa: {}", tenantId, e.getMessage());
+                dead.add(emitter);
+            }
+        }
+
+        dead.forEach(e -> removeEmitter(tenantId, e));
+    }
+
+    private void removeEmitter(Long tenantId, SseEmitter emitter) {
+        CopyOnWriteArrayList<SseEmitter> list = emittersByTenant.get(tenantId);
+        if (list != null) {
+            list.remove(emitter);
+            if (list.isEmpty()) {
+                emittersByTenant.remove(tenantId);
+            }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        log.info("[SSE] Cerrando todos los emitters SSE activos...");
+        emittersByTenant.forEach((tenantId, emitters) ->
+                emitters.forEach(SseEmitter::complete));
+        emittersByTenant.clear();
+    }
+}


### PR DESCRIPTION
This pull request introduces real-time order notifications via Server-Sent Events (SSE) for tenants, enabling the frontend to receive immediate updates when new orders are created, especially those originating from the chatbot. The implementation includes a new REST controller, a comprehensive event DTO tailored for frontend needs, and a service that manages subscriptions, event broadcasting, and connection health.

**SSE Orders Real-Time Notification System**

*New SSE API and Event Flow:*
- Added `OrderSseController` with an endpoint `/api/sse/orders` that allows clients to subscribe for real-time order events per tenant. The controller delegates to a service that manages the SSE emitters.
- Introduced `OrderSseService` to handle emitter registration, event broadcasting, and connection cleanup. It supports sending "new-order" events for chatbot-originated, pending orders and periodic heartbeat "ping" events to keep connections alive.

*Event Data Structure:*
- Created `OrderSseEventDTO`, a detailed DTO for SSE events, including metadata, order details, and item-level information, formatted and mapped specifically for frontend consumption. This includes English status values and all necessary order fields.

*Key Implementation Details:*
- Ensures robust emitter lifecycle management, including cleanup on disconnects/errors and graceful shutdown of all emitters on service termination.
- Provides mapping logic to translate backend order statuses from Spanish to English and to handle null/default values for order fields to ensure frontend compatibility.
[Copilot is generating a summary...]